### PR TITLE
Fix missing argument handling in count command

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -639,7 +639,11 @@ impl App {
         else if command.trim().starts_with('/'){
             Ok(Some(Operations::Find(String::from(command.trim().trim_start_matches("/")))))
         } else if command.trim() == "count" {
-            Ok(Some(Operations::WordCount(String::from(args[0]))))
+            if let Some(word) = args.get(0) {
+                Ok(Some(Operations::WordCount((*word).to_string())))
+            } else {
+                Err("No word provided for count command".into())
+            }
         } else if command.trim() == "list" {
             Ok(Some(Operations::List))
         }else if command.trim() == "clundo" {


### PR DESCRIPTION
## Summary
- prevent panic when `:count` command runs without an argument

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683fff9433f083228dd9152b52e2fdf5